### PR TITLE
Add streamvbyte wrapper as well

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "simdintersection-sys/SIMDCompressionAndIntersection"]
 	path = simdintersection-sys/SIMDCompressionAndIntersection
 	url = https://github.com/lemire/SIMDCompressionAndIntersection.git
+[submodule "streamvbyte-sys/streamvbyte"]
+	path = streamvbyte-sys/streamvbyte
+	url = https://github.com/lemire/streamvbyte.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ autobenches = false
 
 [dependencies]
 simdintersection-sys = { path = "simdintersection-sys" }
+streamvbyte-sys = { path = "streamvbyte-sys" }
 
 [dev-dependencies]
 slow-intersection = { path = "slow-intersection" }

--- a/lib.rs
+++ b/lib.rs
@@ -1,6 +1,8 @@
 extern crate simdintersection_sys;
+extern crate streamvbyte_sys;
 use std::cmp;
 
+// SIMD Intersection
 pub fn simd_intersection(set1: &[u32], set2: &[u32]) -> Vec<u32> {
     unsafe {
         let len1 = set1.len();
@@ -102,4 +104,139 @@ mod fuzz_tests {
             assert_eq!(simd, hash);
         }
     }
+}
+
+// streambyte
+pub fn streamvbyte_encode(in_: &[u32]) -> Vec<u8> {
+    unsafe {
+        let len = in_.len();
+        let pin = in_.as_ptr();
+
+        let maxlen = streamvbyte_sys::streamvbyte_max_compressedbytes(len);
+        let mut dst = Vec::with_capacity(maxlen);
+        let pdst = dst.as_mut_ptr();
+
+        let dstlen = streamvbyte_sys::streamvbyte_encode(
+            pin,
+            len as u32,
+            pdst
+        );
+        dst.set_len(dstlen);
+        dst
+    }
+}
+pub fn streamvbyte_decode(in_: &[u8], num_ints: usize) -> Vec<u32> {
+    unsafe {
+        let pin = in_.as_ptr();
+
+        let mut dst = Vec::with_capacity(num_ints);
+        let pdst = dst.as_mut_ptr();
+
+        streamvbyte_sys::streamvbyte_decode(
+            pin,
+            pdst,
+            num_ints as u32
+        );
+        dst.set_len(num_ints);
+        dst
+    }
+}
+
+#[test]
+fn simple_encode_decode() {
+    let data: Vec<u32> = vec![0,1,2,3,4,5,6,7,8,9,10];
+    let encoded = streamvbyte_encode(&data);
+    let decoded = streamvbyte_decode(&encoded, data.len());
+    assert!(encoded.len() < data.len() * 4);
+    assert_eq!(data, decoded);
+}
+
+pub fn streamvbyte_encode_0124(in_: &[u32]) -> Vec<u8> {
+    unsafe {
+        let len = in_.len();
+        let pin = in_.as_ptr();
+
+        let maxlen = streamvbyte_sys::streamvbyte_max_compressedbytes(len);
+        let mut dst = Vec::with_capacity(maxlen);
+        let pdst = dst.as_mut_ptr();
+
+        let dstlen = streamvbyte_sys::streamvbyte_encode_0124(
+            pin,
+            len as u32,
+            pdst
+        );
+        dst.set_len(dstlen);
+        dst
+    }
+}
+pub fn streamvbyte_decode_0124(in_: &[u8], num_ints: usize) -> Vec<u32> {
+    unsafe {
+        let pin = in_.as_ptr();
+
+        let mut dst = Vec::with_capacity(num_ints);
+        let pdst = dst.as_mut_ptr();
+
+        streamvbyte_sys::streamvbyte_decode_0124(
+            pin,
+            pdst,
+            num_ints as u32
+        );
+        dst.set_len(num_ints);
+        dst
+    }
+}
+
+#[test]
+fn simple_encode_decode_0124() {
+    let data: Vec<u32> = vec![0,1,2,3,4,5,6,7,8,9,10];
+    let encoded = streamvbyte_encode_0124(&data);
+    let decoded = streamvbyte_decode_0124(&encoded, data.len());
+    assert!(encoded.len() < data.len() * 4);
+    assert_eq!(data, decoded);
+}
+
+pub fn streamvbyte_delta_encode(in_: &[u32], prev: u32) -> Vec<u8> {
+    unsafe {
+        let len = in_.len();
+        let pin = in_.as_ptr();
+
+        let maxlen = streamvbyte_sys::streamvbyte_max_compressedbytes(len);
+        let mut dst = Vec::with_capacity(maxlen);
+        let pdst = dst.as_mut_ptr();
+
+        let dstlen = streamvbyte_sys::streamvbyte_delta_encode(
+            pin,
+            len as u32,
+            pdst,
+            prev
+        );
+        dst.set_len(dstlen);
+        dst
+    }
+}
+pub fn streamvbyte_delta_decode(in_: &[u8], num_ints: usize, prev: u32) -> Vec<u32> {
+    unsafe {
+        let pin = in_.as_ptr();
+
+        let mut dst = Vec::with_capacity(num_ints);
+        let pdst = dst.as_mut_ptr();
+
+        streamvbyte_sys::streamvbyte_delta_decode(
+            pin,
+            pdst,
+            num_ints as u32,
+            prev
+        );
+        dst.set_len(num_ints);
+        dst
+    }
+}
+
+#[test]
+fn simple_encode_decode_delta() {
+    let data: Vec<u32> = vec![0,1,2,3,4,5,6,7,8,9,10];
+    let encoded = streamvbyte_delta_encode(&data, 0);
+    let decoded = streamvbyte_delta_decode(&encoded, data.len(), 0);
+    assert!(encoded.len() < data.len() * 4);
+    assert_eq!(data, decoded);
 }

--- a/streamvbyte-sys/Cargo.toml
+++ b/streamvbyte-sys/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "streamvbyte-sys"
+version = "0.1.0"
+authors = ["Andrew Pendleton <andrew@mapbox.com>"]
+
+[dependencies]
+
+[build-dependencies]
+cc = "1.0"
+
+[lib]
+name = "streamvbyte_sys"
+path = "lib.rs"

--- a/streamvbyte-sys/build.rs
+++ b/streamvbyte-sys/build.rs
@@ -1,0 +1,38 @@
+extern crate cc;
+
+use std::env;
+use std::path::{PathBuf, Path};
+use std::process::Command;
+
+fn main() {
+    if !Path::new("streamvbyte/.git").exists() {
+        let _ = Command::new("git").args(&["submodule", "update", "--init"])
+                                   .status();
+    }
+
+    let dst = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let build = dst.join("build");
+
+    let mut cfg = cc::Build::new();
+    cfg.out_dir(&build)
+        .include("streamvbyte/include")
+
+        .file("streamvbyte/src/streamvbyte_0124_decode.c")
+        .file("streamvbyte/src/streamvbyte_0124_encode.c")
+        .file("streamvbyte/src/streamvbyte_decode.c")
+        .file("streamvbyte/src/streamvbyte_encode.c")
+        .file("streamvbyte/src/streamvbytedelta_decode.c")
+        .file("streamvbyte/src/streamvbytedelta_encode.c")
+
+        .flag("-fPIC")
+        .flag("-march=native")
+        .flag("-std=c99")
+        .flag("-O3")
+        .flag("-Wall")
+        .flag("-Wextra")
+        .flag("-pedantic")
+        .flag("-Wshadow")
+
+        .compile("streamvbyte");
+}
+

--- a/streamvbyte-sys/lib.rs
+++ b/streamvbyte-sys/lib.rs
@@ -1,0 +1,46 @@
+use std::mem::size_of;
+
+extern {
+    pub fn streamvbyte_encode(
+        in_: *const u32,
+        length: u32,
+        out: *mut u8
+    ) -> usize;
+    pub fn streamvbyte_decode(
+        in_: *const u8,
+        out: *mut u32,
+        length: u32,
+    ) -> usize;
+    pub fn streamvbyte_encode_0124(
+        in_: *const u32,
+        length: u32,
+        out: *mut u8
+    ) -> usize;
+    pub fn streamvbyte_decode_0124(
+        in_: *const u8,
+        out: *mut u32,
+        length: u32,
+    ) -> usize;
+    pub fn streamvbyte_delta_encode(
+        in_: *const u32,
+        length: u32,
+        out: *mut u8,
+        prev: u32,
+    ) -> usize;
+    pub fn streamvbyte_delta_decode(
+        in_: *const u8,
+        out: *mut u32,
+        length: u32,
+        prev: u32,
+    ) -> usize;
+}
+
+// this is a port rather than a wrapper, because it's declared as inline on the C side
+#[inline]
+pub fn streamvbyte_max_compressedbytes(length: usize) -> usize {
+    // number of control bytes:
+    let cb = (length + 3) / 4;
+    // maximum number of control bytes:
+    let db = length * size_of::<u32>();
+    cb + db
+}


### PR DESCRIPTION
The two common operations for building inverted indexes are compressing and decompressing ID lists, and intersecting them. In addition to the already-present intersection implementation, this PR adds a wrapper around an integer list compressor, [streamvbyte](https://github.com/lemire/streamvbyte), also by Daniel Lemire.

# FAQ
## Is this orthogonal to the purposes of the library?
Probably, but I want them both so I don't care very much.

## Why not use a Rust compressor?
https://github.com/tantivy-search/bitpacking from Tantivy seems hard to use (requires knowledge of the internal block size used by the compressor). The [existing Rust port of stream-vbyte](https://bitbucket.org/marshallpierce/stream-vbyte-rust/) doesn't seem maintained, and also requires unstable Rust. I think it might be possible to get it to compile on stable, given that some SIMD stuff has stabilized since it was last touched, but I tried for a couple of hours and gave up.

## Why not use one of the C++ compressors in the library you're already wrapping?
This library started out as a wrapper around https://github.com/lemire/SIMDCompressionAndIntersection which already contains a bunch of implementations of integer list compressors, including one for streamvbyte. The C++ implementation is apparently not vectorized though, per https://github.com/lemire/SIMDCompressionAndIntersection/issues/22, so I opted for the C one instead under the assumption that it will be faster.